### PR TITLE
[TSK-657] KP 2.0.1 and 4 Uvicorn Workers

### DIFF
--- a/releases/production/patch-kernel-planckster.yaml
+++ b/releases/production/patch-kernel-planckster.yaml
@@ -23,10 +23,12 @@ spec:
           kubernetes.io/hostname: "sda-worker-03"
       containers:
         - name: kernel-planckster
-          image: maany/kernel-planckster:2.0.0
+          image: maany/kernel-planckster:2.0.1
           env:
-            - name: KP_ALLOWED_ORIGINS
+            - name: KP_FASTAPI_ALLOWED_ORIGINS
               value: "*.cluster.local, *.devmaany.com"
+            - name: KP_FASTAPI_WORKERS
+              value: "4"
             - name: KP_OBJECT_STORE_HOST
               value: "sda-minio.devmaany.com"
             - name: KP_OBJECT_STORE_PORT


### PR DESCRIPTION
This pull request includes updates to the `releases/production/patch-kernel-planckster.yaml` file to enhance the deployment configuration for the `kernel-planckster` container. The most important changes include updating the container image version and modifying environment variables.

Deployment configuration updates:

* Updated the `kernel-planckster` container image version from `2.0.0` to `2.0.1`.
* Changed the environment variable `KP_ALLOWED_ORIGINS` to `KP_FASTAPI_ALLOWED_ORIGINS`.
* Added a new environment variable `KP_FASTAPI_WORKERS` with a value of `4`.